### PR TITLE
rstudio4.1: Quay base image

### DIFF
--- a/rstudio4.1/Dockerfile
+++ b/rstudio4.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/rstudio:4.1.0
+FROM quay.io/cdis/rocker-rstudio:4.1.0
 
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libxml2-dev \


### PR DESCRIPTION
I pushed the base image to rocker-rstudio because the rstudio repo on Quay is taken